### PR TITLE
既存カメラの表示範囲を画面端点の座標に固定

### DIFF
--- a/Assets/Scenes/Scene01.unity
+++ b/Assets/Scenes/Scene01.unity
@@ -261,7 +261,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &70547634
 GameObject:
@@ -403,7 +403,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &75249049
 GameObject:
@@ -639,7 +639,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &498635883
 GameObject:
@@ -781,7 +781,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &519420028
 GameObject:
@@ -1041,7 +1041,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &986415622
 GameObject:
@@ -1108,7 +1108,7 @@ Transform:
   m_Children:
   - {fileID: 75249050}
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1338576896
 GameObject:
@@ -1227,7 +1227,7 @@ Transform:
   m_LocalScale: {x: 0.2, y: 0.2, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!61 &1338576901
 BoxCollider2D:
@@ -1255,6 +1255,80 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 4, y: 4}
   m_EdgeRadius: 0
+--- !u!1 &1389826334
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1389826337}
+  - component: {fileID: 1389826336}
+  m_Layer: 5
+  m_Name: Field Camera
+  m_TagString: Field Camera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!20 &1389826336
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1389826334}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.1
+  far clip plane: 5000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 6.4966416
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 0
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 0
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1389826337
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1389826334}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.3298228, y: 1.0002344, z: -238.68787}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1505110871
 GameObject:
   m_ObjectHideFlags: 0
@@ -1395,7 +1469,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1797634651
 GameObject:
@@ -1537,7 +1611,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1880557068
 GameObject:
@@ -1679,5 +1753,5 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/PlayerMove.cs
+++ b/Assets/Scripts/PlayerMove.cs
@@ -5,23 +5,32 @@ public class PlayerMove : MonoBehaviour
 {
 	public float speed = 30.0f;
 
+	private Camera _fieldCamera;
 	[SerializeField] private Transform target;
 
 	void Start()
     {
+		GameObject obj = GameObject.Find("Field Camera");
+		_fieldCamera = obj.GetComponent<Camera>();
+
+		// 画面の端点の座標
+		Debug.Log(getScreenTopRight().x);
+		Debug.Log(getScreenTopRight().y);
+		Debug.Log(getScreenBottomLeft().x);
+		Debug.Log(getScreenBottomLeft().y);
+
 	}
 
 	// Update is called once per frame
 	void Update()
 	{
-		Vector3 pos = target.position;
+		Vector3 playerPosition = target.position;
 
 		if (Input.GetKey("right"))
 		{
-			if (pos.y < -4.8)
+			if (playerPosition.x > getScreenTopRight().x)
 			{
 				transform.position -= transform.right * speed * Time.deltaTime;
-				Debug.Log(pos);
 			}
 			else
 			{
@@ -31,10 +40,9 @@ public class PlayerMove : MonoBehaviour
 		}
 		if (Input.GetKey("left"))
 		{
-			if (pos.y > 5.6)
+			if (playerPosition.x < getScreenBottomLeft().x)
 			{
 				transform.position += transform.right * speed * Time.deltaTime;
-				Debug.Log(pos);
 			}
 			else
 			{
@@ -43,16 +51,40 @@ public class PlayerMove : MonoBehaviour
 		}
 		if (Input.GetKey("up"))
 		{
-			transform.position += transform.up * speed * Time.deltaTime;
+			if (playerPosition.y > getScreenTopRight().y)
+			{
+				transform.position -= transform.up * speed * Time.deltaTime;
+			}
+            else
+			{
+				transform.position += transform.up * speed * Time.deltaTime;
+			}
 		}
 		if (Input.GetKey("down"))
 		{
-			transform.position -= transform.up * speed * Time.deltaTime;
+			if (playerPosition.y < getScreenBottomLeft().y)
+			{
+				transform.position += transform.up * speed * Time.deltaTime;
+			}
+			else
+			{
+				transform.position -= transform.up * speed * Time.deltaTime;
+			}
 		}
 
-		//Vector3 pos = target.position;
+	}
 
-		// Debug.Log(pos); // z座標が可変
+	private Vector3 getScreenBottomLeft()
+	{
+		// 画面の左上を取得
+		Vector3 bottomLeft = _fieldCamera.ScreenToWorldPoint(Vector3.zero);
+		return bottomLeft;
+	}
 
+	private Vector3 getScreenTopRight()
+	{
+		// 画面の右下を取得
+		Vector3 topRight = _fieldCamera.ScreenToWorldPoint(new Vector3(Screen.width, Screen.height, 0.0f));
+		return topRight;
 	}
 }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Field Camera
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
プロジェクト再構成時にオブジェクトの座標を90度回転させたことに伴い、画面端点の座標が変化したため、フィールド座標取得用のサブカメラから画面端点の座標を取得できるように微修正を行いました。